### PR TITLE
Updating documentation to note sqlite3 backend

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -11,6 +11,8 @@ description: |-
 The PowerDNS provider is used manipulate DNS records supported by PowerDNS server. The provider needs to be configured
 with the proper credentials before it can be used. It supports both the [legacy API](https://doc.powerdns.com/3/httpapi/api_spec/) and the new [version 1 API](https://doc.powerdns.com/md/httpapi/api_spec/), however resources may need to be configured differently.
 
+NOTE: if you're using the sqlite3 PowerDNS backend, you must not use parllel execution: `-parallelism=1`. The MySQL Backend has been verified to work with parallelism, however.
+
 Use the navigation to the left to read about the available resources.
 
 ## Example Usage

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -11,7 +11,9 @@ description: |-
 The PowerDNS provider is used manipulate DNS records supported by PowerDNS server. The provider needs to be configured
 with the proper credentials before it can be used. It supports both the [legacy API](https://doc.powerdns.com/3/httpapi/api_spec/) and the new [version 1 API](https://doc.powerdns.com/md/httpapi/api_spec/), however resources may need to be configured differently.
 
-NOTE: if you're using the sqlite3 PowerDNS backend, you must not use parllel execution: `-parallelism=1`. The MySQL Backend has been verified to work with parallelism, however.
+NOTE: if you're using the sqlite3 PowerDNS backend, you might face a problem (as described in [#75](https://github.com/pan-net/terraform-provider-powerdns/issues/75)) with terraform's
+default behavior to [run mulitple operations](https://www.terraform.io/docs/commands/apply.html#parallelism-n) in parallel. Using `-parallelism=1` can help solve the limitations of
+the sqlite3 PowerDNS Backend. The MySQL Backend has been verified to work with parallelism, however.
 
 Use the navigation to the left to read about the available resources.
 


### PR DESCRIPTION
Resolves #75 via documentation

I just updated the page that I think gets published to the hashicorp documentation repo. I'm happy to tweak where it goes, but I think this is suitable.