### PR TITLE
Adds a check for 403 unauthorized

### DIFF
--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -279,6 +279,8 @@ func (client *Client) detectAPIVersion() (int, error) {
 	defer resp.Body.Close()
 	if resp.StatusCode == 200 {
 		return 1, nil
+	} else if resp.StatusCode == 403 {
+		return -1, fmt.Errorf("Error while authenticating: %s", resp.Status)
 	}
 	return 0, nil
 }


### PR DESCRIPTION
Simple PR to just add a check for 403 when determining the apiVersion.

Currently a 403 results in a 0 being returned therefore if the server requires /api/v1 in the URL it will instead succeed in "passing" the version detection, and default to querying the server on /servers/localhost which ultimately results in a 404 which can be misleading when the simple fix was just the API key was wrong.